### PR TITLE
Feature: Support for multiple toasts

### DIFF
--- a/src/useToast.tsx
+++ b/src/useToast.tsx
@@ -122,6 +122,7 @@ export const ToastProvider: FC<Props> = ({ value, children }) => {
       {children}
       {toasts.map((toast, i) => (
         <IonToast
+          key={i}
           ref={(ref) => (toasts[i].ref = ref)}
           isOpen={toast.isOpen}
           onDidDismiss={() => hideToast(i)}


### PR DESCRIPTION
I found a few cases where it was actually needed to be able to place toast messages on top of each other. Currently, this package only allows one at a time so this PR solves that by allowing multiple toast messages to appear. This PR may not be fully complete since it doesn't update documentation and there might be some design decisions we should think about such as replacing dismiss with dismissAll() since that's what it will actually do. 

Let me know your thoughts.