### PR TITLE
Fix: React 18 needs explicit children prop def

### DIFF
--- a/src/useToast.tsx
+++ b/src/useToast.tsx
@@ -2,6 +2,7 @@ import React, {
   createContext,
   useContext,
   FC,
+  ReactNode,
   useCallback,
   useMemo,
   useState,
@@ -29,6 +30,7 @@ const { Provider } = ToastContext;
 
 interface Props {
   value?: ToastOptions;
+  children?: ReactNode;
 }
 
 export const useToast = () => useContext(ToastContext) as ToastProviderOptions;


### PR DESCRIPTION
In React 18 the FunctionComponent interface no longer comes with the children prop as you can read here (https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions).

This pull request aims to fix the issue by declaring explicitly the children prop.